### PR TITLE
Adds a feedback form in the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ docs/
 # Backup files
 .bak/
 
+# Feedback file
+.feedback
+
 # Poetry
 .venv/
 dist/


### PR DESCRIPTION
# Metadata

- **Fixed Issue**: #6
- **Contributors**: @iosifache

# Proposed Changes

- Adds a feedback form for testers

# New Functioning

MutableSecurity will show on its first run a message and an input for email addresses. After that, is can be shown only by requesting it explicitly by providing the `--feedback` flag.