### PR TITLE
Implements the remote login with SSH key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Some documentation files
-docs/
-
 # Backup files
 .bak/
 

--- a/mutablesecurity/modules/leader/__init__.py
+++ b/mutablesecurity/modules/leader/__init__.py
@@ -1,1 +1,1 @@
-from .leader import Leader
+from .leader import ConnectionDetails, Leader

--- a/mutablesecurity/modules/leader/leader.py
+++ b/mutablesecurity/modules/leader/leader.py
@@ -2,37 +2,46 @@ from pyinfra.api import Config, Inventory, State
 from pyinfra.api.connect import connect_all
 
 
+class ConnectionDetails(dict):
+    def __init__(self, hostname, port, username, key, password):
+        self.hostname = hostname
+        self.port = port
+        self.username = username
+        self.key = key
+        self.password = password
+
+
 class Leader:
     @staticmethod
     def _make_inventory(hosts=(), **kwargs):
         return Inventory((hosts, {}), **kwargs)
 
     @staticmethod
-    def connect_to_local(password):
+    def connect_to_local(details):
         # Create the local connection with pyinfra
         inventory = Leader._make_inventory(hosts=("@local",))
         state = State(inventory, Config())
         connect_all(state)
 
         state.config.SUDO = True
-        state.config.USE_SUDO_PASSWORD = password
+        state.config.USE_SUDO_PASSWORD = details.password
 
         return state
 
     @staticmethod
-    def connect_to_ssh_with_password(host, ssh_port, ssh_user, ssh_password):
+    def _connect_to_ssh_with_params(details, additional_pyinfra_params):
         # Create the inventory with the specified host
+        ssh_connection_details = {
+            "ssh_port": details.port,
+            "ssh_user": details.username,
+            "allow_agent": False,
+        }
+        ssh_connection_details |= additional_pyinfra_params
         inventory = Leader._make_inventory(
             hosts=(
                 (
-                    host,
-                    {
-                        "ssh_port": ssh_port,
-                        "ssh_user": ssh_user,
-                        "ssh_password": ssh_password,
-                        "allow_agent": False,
-                        "look_for_keys": False,
-                    },
+                    details.hostname,
+                    ssh_connection_details,
                 ),
             )
         )
@@ -43,4 +52,25 @@ class Leader:
         # Connect
         connect_all(state)
 
+        state.config.SUDO = True
+        state.config.USE_SUDO_PASSWORD = details.password
+
         return state
+
+    @staticmethod
+    def connect_to_ssh_with_password(details):
+        params = {
+            "ssh_password": details.password,
+            "look_for_keys": False,
+        }
+
+        return Leader._connect_to_ssh_with_params(details, params)
+
+    @staticmethod
+    def connect_to_ssh_with_key(details):
+        params = {
+            "ssh_key": details.key,
+            "ssh_key_password": details.password,
+        }
+
+        return Leader._connect_to_ssh_with_params(details, params)

--- a/mutablesecurity/modules/main/main.py
+++ b/mutablesecurity/modules/main/main.py
@@ -5,7 +5,7 @@ from pyinfra.api.deploy import add_deploy
 from pyinfra.api.exceptions import PyinfraError
 from pyinfra.api.operations import run_ops
 
-from ..leader import Leader
+from ..leader import ConnectionDetails, Leader
 from ..solutions_manager import AbstractSolution, AvailableSolution, SolutionsManager
 
 
@@ -33,14 +33,13 @@ class Main:
     def run(connection_details, solution_name, operation_name, additional_arguments):
         try:
             # Connect to local or remote depending on the set host
-            if connection_details[0]:
-                host, ssh_port, ssh_user, ssh_password = connection_details
-                state = Leader.connect_to_ssh_with_password(
-                    host, ssh_port, ssh_user, ssh_password
-                )
+            if connection_details.hostname:
+                if connection_details.key:
+                    state = Leader.connect_to_ssh_with_key(connection_details)
+                else:
+                    state = Leader.connect_to_ssh_with_password(connection_details)
             else:
-                local_password = connection_details[3]
-                state = Leader.connect_to_local(local_password)
+                state = Leader.connect_to_local(connection_details)
         except:
             return {
                 "success": False,


### PR DESCRIPTION
# Metadata

- **Fixed Issue**: #15
- **Contributors**: @iosifache

# Proposed Changes

- Adding a new parameter, `--key` or `-k`, for specifying the private key
- Changes in the Leader module to call `pyinfra` with the proper parameters to connect with a key

# New Functioning

MutableSecurity can now connect to a remote host by using a private key that was already added (for example, with `ssh-copy-id`).

```
mutablesecurity -r iosifache@172.18.0.1:22 -k /home/iosifache/.ssh/vm -s SURICATA -o GET_CONFIGURATION
🔐 Password for /home/iosifache/.ssh/vm and iosifache@172.18.0.1:22: 
✅ The configuration of Suricata was retrieved.

┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Attribute         ┃ Value   ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ automatic_updates │ ENABLED │
│ interface         │ enp0s3  │
└───────────────────┴─────────┘
```