### PR TITLE
Adds support for Let's Encrypt 

### DIFF
--- a/mutablesecurity/cli.py
+++ b/mutablesecurity/cli.py
@@ -236,7 +236,7 @@ def _print_response(responses):
         text.append(str(Emoji(emoji)))
 
         # Plug the host, the message and the addition sent data
-        text.append(" " + response["host"].name + ": " + response["message"])
+        text.append(" " + response["host"] + ": " + response["message"])
 
         # Print the message
         console.print(text)

--- a/mutablesecurity/modules/exceptions.py
+++ b/mutablesecurity/modules/exceptions.py
@@ -1,0 +1,14 @@
+class MutableSecurityException(Exception):
+    """Generic MutableSecurity exception"""
+
+    def __init__(self) -> None:
+        """Initializes the MutableSecurityException instance."""
+        super(Exception, self).__init__(self.__doc__)
+
+
+class MandatoryAspectLeftUnsetException(MutableSecurityException):
+    """A mandatory aspect of the default configuration was left unset."""
+
+
+class SameSetConfigurationValue(MutableSecurityException):
+    """The value set in the configuration is the same with the old one."""

--- a/mutablesecurity/modules/main/main.py
+++ b/mutablesecurity/modules/main/main.py
@@ -90,9 +90,8 @@ class Main:
         else:
             # Check the result
             results = getattr(solution_class, "result")
-            for result in results:
-                host, host_result = result
-                if not host_result:
+            for host, result in results.items():
+                if not result:
                     is_fail = True
                 else:
                     is_fail = False
@@ -103,7 +102,7 @@ class Main:
                     "host": host,
                     "success": not is_fail,
                     "message": message,
-                    "raw_result": result[1],
+                    "raw_result": result,
                 }
                 responses.append(response)
 

--- a/mutablesecurity/modules/solutions_manager/deployments/managed_stats.py
+++ b/mutablesecurity/modules/solutions_manager/deployments/managed_stats.py
@@ -1,3 +1,5 @@
+import inspect
+
 from pyinfra.api.deploy import deploy
 
 
@@ -9,6 +11,21 @@ class ManagedStats:
         result = {}
         metrics_config = solution_class.meta["metrics"]
         for _, value in metrics_config.items():
-            result[value["description"]] = host.get_fact(value["fact"])
+            fact = value["fact"]
+            kwargs = {}
+
+            # Check if the stat requires paramets
+            command = fact.command
+            if callable(command):
+                parameters = inspect.signature(command).parameters
+                if len(parameters) > 1:
+                    # Get the parameters from class' configuration
+                    kwargs = {
+                        key: solution_class._configuration[key]
+                        for key in parameters
+                        if key != "self"
+                    }
+
+            result[value["description"]] = host.get_fact(fact, **kwargs)
 
         solution_class.result.append((host, result))

--- a/mutablesecurity/modules/solutions_manager/deployments/managed_stats.py
+++ b/mutablesecurity/modules/solutions_manager/deployments/managed_stats.py
@@ -28,4 +28,4 @@ class ManagedStats:
 
             result[value["description"]] = host.get_fact(fact, **kwargs)
 
-        solution_class.result.append((host, result))
+        solution_class.result[host.name] = result

--- a/mutablesecurity/modules/solutions_manager/deployments/managed_yaml_backed_config.py
+++ b/mutablesecurity/modules/solutions_manager/deployments/managed_yaml_backed_config.py
@@ -18,9 +18,6 @@ class ManagedYAMLBackedConfig:
 
     @deploy
     def _check_installation_config(state, host, solution_class):
-        # Get the actual configuration
-        solution_class.get_configuration(state=state, host=host)
-
         # Check each key in the coniguration
         configuration_meta = solution_class.meta["configuration"]
         for key, _ in configuration_meta.items():

--- a/mutablesecurity/modules/solutions_manager/deployments/managed_yaml_backed_config.py
+++ b/mutablesecurity/modules/solutions_manager/deployments/managed_yaml_backed_config.py
@@ -83,7 +83,7 @@ class ManagedYAMLBackedConfig:
                 state=state, host=host, solution_class=solution_class
             )
 
-        solution_class.result.append((host, solution_class._configuration))
+        solution_class.result[host.name] = solution_class._configuration
 
     @deploy
     def _verify_new_configuration(state, host, solution_class, aspect, value):
@@ -103,7 +103,7 @@ class ManagedYAMLBackedConfig:
         except KeyError:
             pass
 
-        solution_class.result.append((host, real_value is not None))
+        solution_class.result[host.name] = real_value is not None
 
     @deploy
     def set_configuration(state, host, solution_class, aspect, value):
@@ -112,7 +112,7 @@ class ManagedYAMLBackedConfig:
             state=state, host=host, aspect=aspect, value=value
         )
         if not solution_class.result:
-            solution_class.result.append((host, False))
+            solution_class.result[host.name] = False
 
             return
 
@@ -148,7 +148,7 @@ class ManagedYAMLBackedConfig:
                 new_value=value,
             )
 
-        solution_class.result.append((host, True))
+        solution_class.result[host.name] = True
 
     @deploy
     def _put_configuration(state, host, solution_class):
@@ -167,4 +167,4 @@ class ManagedYAMLBackedConfig:
             dest=ManagedYAMLBackedConfig._get_configuration_filename(solution_class),
         )
 
-        solution_class.result.append((host, True))
+        solution_class.result[host.name] = True

--- a/mutablesecurity/modules/solutions_manager/deployments/managed_yaml_backed_config.py
+++ b/mutablesecurity/modules/solutions_manager/deployments/managed_yaml_backed_config.py
@@ -4,17 +4,39 @@ from io import StringIO
 import yaml
 from pyinfra.api import FactBase
 from pyinfra.api.deploy import deploy
-from pyinfra.operations import files
+from pyinfra.api.exceptions import PyinfraError
+from pyinfra.operations import files, python
+
+from ...exceptions import MandatoryAspectLeftUnsetException, SameSetConfigurationValue
 
 
 class ManagedYAMLBackedConfig:
+    def _get_configuration_filename(solution_class):
+        solution_id = solution_class.meta["id"]
+
+        return f"/opt/mutablesecurity/{solution_id}/{solution_id}.conf"
+
+    @deploy
+    def _check_installation_config(state, host, solution_class):
+        # Get the actual configuration
+        solution_class.get_configuration(state=state, host=host)
+
+        # Check each key in the coniguration
+        configuration_meta = solution_class.meta["configuration"]
+        for key, _ in configuration_meta.items():
+            # Check the default aspects to be set
+            if not solution_class._configuration[key]:
+                raise MandatoryAspectLeftUnsetException()
+
+        return True
+
     @deploy
     def _set_default_configuration(state, host, solution_class):
         configuration_meta = solution_class.meta["configuration"]
 
         initial_config = {}
         for key, value in configuration_meta.items():
-            initial_config[key] = str(value["default"])
+            initial_config[key] = value["default"]
 
         solution_class._configuration = initial_config
 
@@ -28,14 +50,22 @@ class ManagedYAMLBackedConfig:
 
                 solution_class_name = solution_class.__name__.lower()
 
-                return f"cat /opt/mutablesecurity/{solution_class_name}/{solution_class_name}.conf"
+                return f"cat {ManagedYAMLBackedConfig._get_configuration_filename(solution_class)} || echo ''"
 
             def process(self, output):
+                if not output[0]:
+                    return None
+
                 output = "\n".join(output)
                 config = yaml.safe_load(output)
 
                 configuration_meta = self.solution_class.meta["configuration"]
                 for key, value in configuration_meta.items():
+                    if config[key] == "None":
+                        config[key] = None
+                        continue
+
+                    # Convert to the real type
                     real_type = value["type"]
                     try:
                         config[key] = real_type(config[key])
@@ -47,6 +77,14 @@ class ManagedYAMLBackedConfig:
         solution_class._configuration = host.get_fact(
             ConfigurationState, solution_class=solution_class
         )
+
+        if not solution_class._configuration:
+            ManagedYAMLBackedConfig._set_default_configuration(
+                state=state, host=host, solution_class=solution_class
+            )
+            ManagedYAMLBackedConfig._put_configuration(
+                state=state, host=host, solution_class=solution_class
+            )
 
         solution_class.result.append((host, solution_class._configuration))
 
@@ -84,7 +122,7 @@ class ManagedYAMLBackedConfig:
         # Get the actual configuration
         solution_class.get_configuration(state=state, host=host)
 
-        # Set the configuration to its new state
+        # Convert the configuration aspect to its real value
         configuration_meta = solution_class.meta["configuration"]
         real_type = configuration_meta[aspect]["type"]
         try:
@@ -92,6 +130,12 @@ class ManagedYAMLBackedConfig:
         except:
             real_value = real_type[value]
         old_value = solution_class._configuration[aspect]
+
+        # Check if the values are the same
+        if real_value == old_value:
+            raise SameSetConfigurationValue()
+
+        # Set the configuration to its new state
         solution_class._configuration[aspect] = real_value
 
         # Upload the new configuration on the server
@@ -117,16 +161,13 @@ class ManagedYAMLBackedConfig:
                     return self.represent_data(data.value)
                 return super().represent_data(data)
 
-        solution_id = solution_class.meta["id"]
-
-        location = f"/opt/mutablesecurity/{solution_id}/{solution_id}.conf"
         files.put(
             state=state,
             host=host,
             sudo=True,
             name="Dumps the solution configuration file",
             src=StringIO(yaml.dump(solution_class._configuration, Dumper=FullDumper)),
-            dest=location,
+            dest=ManagedYAMLBackedConfig._get_configuration_filename(solution_class),
         )
 
         solution_class.result.append((host, True))

--- a/mutablesecurity/modules/solutions_manager/solutions/__init__.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/__init__.py
@@ -6,3 +6,4 @@ from ._abstract import AbstractSolution
 class AvailableSolution(Enum):
     SURICATA = ("suricata", "Suricata")
     TELER = ("teler", "Teler")
+    LETS_ENCRYPT = ("lets_encrypt", "LetsEncrypt")

--- a/mutablesecurity/modules/solutions_manager/solutions/_abstract.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/_abstract.py
@@ -8,7 +8,7 @@ class AbstractSolution(ABC):
 
     _configuration: dict
     meta: dict
-    result: list
+    result: dict
 
     @staticmethod
     @abstractmethod

--- a/mutablesecurity/modules/solutions_manager/solutions/lets_encrypt.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/lets_encrypt.py
@@ -1,0 +1,324 @@
+from datetime import datetime
+
+from genericpath import exists
+from pyinfra.api import FactBase
+from pyinfra.api.deploy import deploy
+from pyinfra.operations import apt, python, server
+
+from ..deployments.managed_stats import ManagedStats
+from ..deployments.managed_yaml_backed_config import ManagedYAMLBackedConfig
+from . import AbstractSolution
+
+
+class SecuredRequests(FactBase):
+    command = "cat /var/log/nginx/https_dev.mutablesecurity.io_access.log | wc -l "
+
+    def process(self, output):
+        return int(output[0])
+
+
+class SecuredRequestsToday(FactBase):
+    def command(self):
+        current_date = datetime.today().strftime("%d/%B/%Y")
+
+        return f"sudo cat /var/log/nginx/https_dev.mutablesecurity.io_access.log | grep '{current_date}' | wc -l"
+
+    def process(self, output):
+        return int(output[0])
+
+
+class Version(FactBase):
+    command = "apt-cache policy certbot | grep -i Installed | cut -d ' ' -f 4"
+
+    def process(self, output):
+        return output[0]
+
+
+class Logs(FactBase):
+    command = "cat /var/log/nginx/https_dev.mutablesecurity.io_access.log"
+
+    def process(self, output):
+        return output
+
+
+class LetsEncrypt(AbstractSolution):
+    meta = {
+        "id": "letsencrypt",
+        "full_name": "Let's Encrypt x Certbot",
+        "description": "Let's Encrypt is a free, automated, and open certificate authority brought to you by the nonprofit Internet Security Research Group (ISRG). Certbot is made by the Electronic Frontier Foundation (EFF), a 501(c)3 nonprofit based in San Francisco, CA, that defends digital privacy, free speech, and innovation.",
+        "references": [
+            "https://letsencrypt.org/",
+            "https://github.com/letsencrypt",
+            "https://certbot.eff.org/",
+            "https://github.com/certbot/certbot",
+        ],
+        "configuration": {
+            "email": {
+                "type": str,
+                "help": "The email provided for security reasons when generating certificates",
+                "default": "hello@mutablesecurity.io",
+            },
+            "domains": {
+                "type": list,
+                "help": "The domain(s) protected by certificates",
+                "default": "staging.mutablesecurity.io",
+            },
+        },
+        "metrics": {
+            "SecuredRequests": {
+                "description": "Total number Secured Requests",
+                "fact": SecuredRequests,
+            },
+            "SecuredRequestsToday": {
+                "description": "Total number of Secured Requests Today",
+                "fact": SecuredRequestsToday,
+            },
+            "version": {"description": "Current installed version", "fact": Version},
+        },
+        "messages": {
+            "GET_CONFIGURATION": (
+                "The configuration of Let's Encrypt x Certbot was retrieved.",
+                "The configuration of Let's Encrypt x Certbot could not be retrieved.",
+            ),
+            "SET_CONFIGURATION": (
+                "The configuration of Let's Encrypt x Certbot was set.",
+                "The configuration of Let's Encrypt x Certbot could not be set. Check the provided aspect and value to be valid.",
+            ),
+            "INSTALL": (
+                "Let's Encrypt x Certbot is now installed on this machine.",
+                "There was an error on Let's Encrypt x Certbot's installation.",
+            ),
+            "TEST": (
+                "Let's Encrypt x Certbot works as expected.",
+                "Let's Encrypt x Certbot does not work as expected.",
+            ),
+            "GET_LOGS": (
+                "The logs of Let's Encrypt x Certbot were retrieved.",
+                "The logs of Let's Encrypt x Certbot could not be retrieved.",
+            ),
+            "GET_STATS": (
+                "The stats of Let's Encrypt x Certbot were retrieved.",
+                "The stats of Let's Encrypt x Certbot could not be retrieved.",
+            ),
+            "UPDATE": (
+                "Let's Encrypt x Certbot is now at its newest version.",
+                "There was an error on Let's Encrypt x Certbot's update.",
+            ),
+            "UNINSTALL": (
+                "Let's Encrypt x Certbot is no longer installed on this machine.",
+                "There was an error on Let's Encrypt x Certbot's uninstallation.",
+            ),
+        },
+    }
+    result = None
+
+    @deploy
+    def get_configuration(state, host):
+        ManagedYAMLBackedConfig.get_configuration(
+            state=state, host=host, solution_class=LetsEncrypt
+        )
+
+    @deploy
+    def _set_default_configuration(state, host):
+        ManagedYAMLBackedConfig._set_default_configuration(
+            state=state, host=host, solution_class=LetsEncrypt
+        )
+
+    @deploy
+    def _verify_new_configuration(state, host, aspect, value):
+        ManagedYAMLBackedConfig._verify_new_configuration(
+            state=state,
+            host=host,
+            solution_class=LetsEncrypt,
+            aspect=aspect,
+            value=value,
+        )
+
+    @deploy
+    def set_configuration(state, host, aspect=None, value=None):
+        ManagedYAMLBackedConfig.set_configuration(
+            state=state,
+            host=host,
+            solution_class=LetsEncrypt,
+            aspect=aspect,
+            value=value,
+        )
+
+    @deploy
+    def _set_configuration_callback(state, host, aspect=None, value=None):
+        # Perform post-setting operations, based on the set configuration
+        pass
+
+    @deploy
+    def _put_configuration(state, host):
+        ManagedYAMLBackedConfig._put_configuration(
+            state=state, host=host, solution_class=LetsEncrypt
+        )
+
+    @deploy
+    def install(state, host):
+        LetsEncrypt._set_default_configuration(state=state, host=host)
+        LetsEncrypt._put_configuration(state=state, host=host)
+
+        file_path = "/opt/mutablesecurity/letsencrypt/default"
+        if not exists(file_path):
+            server.shell(
+                state=state,
+                host=host,
+                sudo=True,
+                name="Saves the default config file in case the user wants to remove LetsEncrypt(Certbot)",
+                commands=[
+                    "cp /etc/nginx/sites-enabled/default /opt/mutablesecurity/letsencrypt/"
+                ],
+            )
+
+        apt.update(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Updates the apt reporisoties",
+            env={"LC_TIME": "en_US.UTF-8"},
+            cache_time=3600,
+            success_exit_codes=[0, 100],
+        )
+
+        apt.packages(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Installs the requirements",
+            packages=["python3-certbot-nginx", "curl"],
+            latest=True,
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Generates and installs the certificates for the given nginx domain",
+            commands=[
+                "certbot --nginx --noninteractive --agree-tos --cert-name staging.mutablesecurity.io -d staging.mutablesecurity.io -m hello@mutablesecurity.io --redirect"
+            ],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Adds MutableSecurity logs command in sites-enabled",
+            commands=[
+                "sed -i '/server_name staging.mutablesecurity.io;/a access_log /var/log/nginx/https_dev.mutablesecurity.io_access.log; # Managed by MutableSecurity' /etc/nginx/sites-enabled/default"
+            ],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Restart the Nginx service",
+            commands=["systemctl restart nginx"],
+        )
+
+        LetsEncrypt.result = True
+
+    @deploy
+    def test(state, host):
+        LetsEncrypt.get_configuration(state=state, host=host)
+
+        curl_command = "curl https://staging.mutablesecurity.io"
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Requests if the https connection is made",
+            commands=[curl_command],
+        )
+
+        def stage(state, host):
+            connections = host.get_fact(SecuredRequestsToday)
+
+            LetsEncrypt.result = connections != 0
+
+        python.call(state=state, host=host, sudo=True, function=stage)
+
+    @deploy
+    def get_stats(state, host):
+        ManagedStats.get_stats(state=state, host=host, solution_class=LetsEncrypt)
+
+    @deploy
+    def get_logs(state, host):
+        LetsEncrypt.get_configuration(state=state, host=host)
+
+        LetsEncrypt.result = host.get_fact(Logs)
+
+    @deploy
+    def update(state, host):
+        apt.packages(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Updates Let's Encrypt x Certbot",
+            packages=["certbot"],
+            latest=True,
+            present=True,
+        )
+
+        LetsEncrypt.result = True
+
+    @deploy
+    def uninstall(state, host):
+        LetsEncrypt.get_configuration(state=state, host=host)
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Revokes the generated certificate",
+            commands=["certbot revoke -n --cert-name staging.mutablesecurity.io"],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Adds all the old configurations back in place on sites-enabled",
+            commands=[
+                "cp /opt/mutablesecurity/letsencrypt/default /etc/nginx/sites-enabled/default"
+            ],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Purges Let's Encrypt x Certbot",
+            commands=["apt purge -y letsencrypt certbot"],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Removes all traces of Let's Encrypt x Certbot",
+            commands=[
+                "rm -rf /etc/letsencrypt /root/.local/share/letsencrypt/ /opt/eff.org/certbot/ /var/lib/letsencrypt/ /var/log/letsencrypt/ /var/log/nginx/https_dev.mutablesecurity.io_access.log /opt/mutablesecurity/letsencrypt/default"
+            ],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Removes everything using autoremove",
+            commands=["apt -y update && apt -y autoremove"],
+        )
+
+        server.shell(
+            state=state,
+            host=host,
+            sudo=True,
+            name="Restarts the Nginx service to apply changes",
+            commands=["systemctl restart nginx"],
+        )
+
+        LetsEncrypt.result = True

--- a/mutablesecurity/modules/solutions_manager/solutions/lets_encrypt.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/lets_encrypt.py
@@ -157,7 +157,7 @@ class LetsEncrypt(AbstractSolution):
         except MandatoryAspectLeftUnsetException:
             pass
         else:
-            # Check if the solution is alreadt installed
+            # Check if the solution is already installed
             if host.get_fact(
                 file_facts.File, "/opt/mutablesecurity/lets_encrypt/default"
             ):
@@ -319,7 +319,7 @@ class LetsEncrypt(AbstractSolution):
             sudo=True,
             name="Removes all traces of Let's Encrypt x Certbot",
             commands=[
-                f"/var/log/nginx/https_{LetsEncrypt._configuration['domain']}_access.log /opt/mutablesecurity/lets_encrypt/default"
+                f"rm /var/log/nginx/https_{LetsEncrypt._configuration['domain']}_access.log /opt/mutablesecurity/lets_encrypt/default"
             ],
         )
 
@@ -343,7 +343,7 @@ class LetsEncrypt(AbstractSolution):
             sudo=True,
             name="Removes all traces of Let's Encrypt x Certbot",
             commands=[
-                f"rm -rf /etc/letsencrypt /root/.local/share/letsencrypt/ /opt/eff.org/certbot/ /var/lib/letsencrypt/ /var/log/letsencrypt/"
+                "rm -rf /etc/letsencrypt /root/.local/share/letsencrypt/ /opt/eff.org/certbot/ /var/lib/letsencrypt/ /var/log/letsencrypt/"
             ],
         )
 

--- a/mutablesecurity/modules/solutions_manager/solutions/lets_encrypt.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/lets_encrypt.py
@@ -114,7 +114,7 @@ class LetsEncrypt(AbstractSolution):
             ),
         },
     }
-    result = None
+    result = {}
 
     @deploy
     def get_configuration(state, host):
@@ -251,7 +251,7 @@ class LetsEncrypt(AbstractSolution):
 
         LetsEncrypt._put_configuration(state=state, host=host)
 
-        LetsEncrypt.result = True
+        LetsEncrypt.result[host.name] = True
 
     @deploy
     def test(state, host):
@@ -271,7 +271,7 @@ class LetsEncrypt(AbstractSolution):
                 SecuredRequestsToday, domain=LetsEncrypt._configuration["domain"]
             )
 
-            LetsEncrypt.result = connections != 0
+            LetsEncrypt.result[host.name] = connections != 0
 
         python.call(state=state, host=host, sudo=True, function=stage)
 
@@ -283,9 +283,8 @@ class LetsEncrypt(AbstractSolution):
     def get_logs(state, host):
         LetsEncrypt.get_configuration(state=state, host=host)
 
-        LetsEncrypt.result = host.get_fact(
-            Logs, domain=LetsEncrypt._configuration["domain"]
-        )
+        logs = host.get_fact(Logs, domain=LetsEncrypt._configuration["domain"])
+        LetsEncrypt.result[host.name] = logs
 
     @deploy
     def update(state, host):
@@ -299,7 +298,7 @@ class LetsEncrypt(AbstractSolution):
             present=True,
         )
 
-        LetsEncrypt.result = True
+        LetsEncrypt.result[host.name] = True
 
     @deploy
     def _revoke_current_certificate(state, host, domain=None):
@@ -374,4 +373,4 @@ class LetsEncrypt(AbstractSolution):
             commands=["systemctl restart nginx"],
         )
 
-        LetsEncrypt.result = True
+        LetsEncrypt.result[host.name] = True

--- a/mutablesecurity/modules/solutions_manager/solutions/suricata.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/suricata.py
@@ -137,7 +137,7 @@ class Suricata(AbstractSolution):
             ),
         },
     }
-    result = []
+    result = {}
 
     @deploy
     def get_configuration(state, host):
@@ -296,7 +296,7 @@ class Suricata(AbstractSolution):
 
         Suricata._put_configuration(state=state, host=host)
 
-        Suricata.result.append((host, True))
+        Suricata.result[host.name] = True
 
     @deploy
     def test(state, host):
@@ -316,7 +316,7 @@ class Suricata(AbstractSolution):
             # request above.
             alerts = host.get_fact(TestAlertsCount)
 
-            Suricata.result.append((host, alerts != 0))
+            Suricata.result[host.name] = alerts != 0
 
         python.call(state=state, host=host, sudo=True, function=stage)
 
@@ -328,7 +328,7 @@ class Suricata(AbstractSolution):
     def get_logs(state, host):
         Suricata.get_configuration(state=state, host=host)
 
-        Suricata.result.append((host, host.get_fact(Logs)))
+        Suricata.result[host.name] = host.get_fact(Logs)
 
     @deploy
     def update(state, host):
@@ -342,7 +342,7 @@ class Suricata(AbstractSolution):
             present=True,
         )
 
-        Suricata.result.append((host, True))
+        Suricata.result[host.name] = True
 
     @deploy
     def uninstall(state, host):
@@ -356,4 +356,4 @@ class Suricata(AbstractSolution):
             commands=["tmux new -d 'apt -y remove suricata'"],
         )
 
-        Suricata.result.append((host, True))
+        Suricata.result[host.name] = True

--- a/mutablesecurity/modules/solutions_manager/solutions/teler.py
+++ b/mutablesecurity/modules/solutions_manager/solutions/teler.py
@@ -162,7 +162,7 @@ class Teler(AbstractSolution):
             ),
         },
     }
-    result = []
+    result = {}
 
     @deploy
     def get_configuration(state, host):
@@ -356,7 +356,7 @@ class Teler(AbstractSolution):
 
         Teler._put_configuration(state=state, host=host)
 
-        Teler.result.append((host, True))
+        Teler.result[host.name] = True
 
     @deploy
     def test(state, host):
@@ -380,7 +380,7 @@ class Teler(AbstractSolution):
             # request above.
             alerts = host.get_fact(TestBadUserAgent)
 
-            Teler.result.append((host, alerts != 0))
+            Teler.result[host.name] = alerts != 0
             host.get_fact(Logs)
 
         python.call(state=state, host=host, sudo=True, function=stage)
@@ -393,7 +393,7 @@ class Teler(AbstractSolution):
     def get_logs(state, host):
         Teler.get_configuration(state=state, host=host)
 
-        Teler.result.append((host, host.get_fact(Logs)))
+        Teler.result[host.name] = host.get_fact(Logs)
 
     @deploy
     def update(state, host):
@@ -402,7 +402,7 @@ class Teler(AbstractSolution):
         local_version = host.get_fact(Version)
         github_latest_version = GitHub.get_latest_release_name("kitabisa", "teler")
         if version.parse(local_version) == version.parse(github_latest_version):
-            Teler.result.append((host, True))
+            Teler.result[host.name] = True
 
             return
 
@@ -460,4 +460,4 @@ class Teler(AbstractSolution):
             present=False,
         )
 
-        Teler.result.append((host, True))
+        Teler.result[host.name] = True


### PR DESCRIPTION
# Metadata

- **Fixed Issue**: #9
- **Contributors**: @AntociAlin @iosifache

# Proposed Changes

- We added support for Let's Encrypt using Certbot.
- We made a rebase for `main`.

# New Functioning

MutableSecurity is able to generate SSL certificates using Let's Encrypt.

# Other Information

The Let's Encrypt module is able to generate and install certificates for only one domain at a time. Furthermore, it has support only for Nginx at this point in time.