### PR TITLE
Publishes the 0.4.0 version of MutableSecurity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## `v0.4.0` | 2022-09-26
+
+### Added
+
+- Adds support for Let's Encrypt x Certbot and ClamAV.
+
 ## `v0.3.1` | 2022-09-13
 
 ### Added
 
-- Adds usage monitoring with custom serverless function and crash monitoring with Sentry
+- Adds usage monitoring with custom serverless function and crash monitoring with Sentry.
 
 ## `v0.3.0` | 2022-08-07
 

--- a/mutablesecurity/__init__.py
+++ b/mutablesecurity/__init__.py
@@ -1,3 +1,3 @@
 """Package storing the MutableSecurity codebase."""
 
-VERSION = "0.3.1"
+VERSION = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mutablesecurity"
-version = "0.3.1"
+version = "0.4.0"
 description = "Seamless deployment and management of cybersecurity solutions"
 keywords = ["cybersecurity", "security-solutions", "hardening", "automatic-deployment"]
 license = "MIT"


### PR DESCRIPTION
# Metadata

- **Fixed Issue**: #68
- **Contributors**: @AntociAlin 

# Proposed Changes

- Adds support for Let's Encrypt x Certbot.
- Adds support for ClamAV.

# New Functioning

- MutableSecurity will be able to offer an AntiMalware and Host Protection security solution: ClamAV and a Web Application Encryption security solution: Let's Encrypt x Certbot.