### PR TITLE
Fixes Regex fail when marking HTML cell as code

### DIFF
--- a/mutablesecurity/autodoc/solution_spec_sheet.py
+++ b/mutablesecurity/autodoc/solution_spec_sheet.py
@@ -212,7 +212,7 @@ def __mark_cells_from_column_as_code(
     def __replace_with_code(match: re.Match) -> str:
         return generate_code_block(match.group())
 
-    pattern = re.compile("([A-Za-z0-9_.]+)")
+    pattern = re.compile("([A-Za-z0-9_./]+)")
 
     row_count = len(matrix)
     for row_id in range(1, row_count):


### PR DESCRIPTION
# Metadata

- **Fixed Issue**: #94 
- **Contributors**: @iosifache

# Proposed Changes

- Only a different regular expression to match code cells

# New Functioning

None