### PR TITLE
added exception tracebacks for devs

### DIFF
--- a/mutablesecurity/cli/cli.py
+++ b/mutablesecurity/cli/cli.py
@@ -278,8 +278,7 @@ def main() -> None:
         if config.developer_mode:
             traceback.print_exc()
         else:
-            Printer(console=console).print_exception(
-            StoppedMutableSecurityException())
+            Printer(console=console).print_exception(StoppedMutableSecurityException())
     except click.BadParameter:
         if config.developer_mode:
             traceback.print_exc()

--- a/mutablesecurity/cli/cli.py
+++ b/mutablesecurity/cli/cli.py
@@ -8,11 +8,13 @@ import sys
 import threading
 import typing
 
+import traceback
 import click
 import gevent.hub
 from rich.console import Console
 from rich.traceback import install
 
+from mutablesecurity import config
 from mutablesecurity.cli.feedback_form import FeedbackForm
 from mutablesecurity.cli.printer import Printer
 from mutablesecurity.cli.solutions_manager_adapter import (
@@ -268,13 +270,22 @@ def main() -> None:
             standalone_mode=False
         )
     except MutableSecurityException as exception:
-        Printer(console=console).print_exception(exception)
+        if config.developer_mode:
+            traceback.print_exc()
+        else:
+            Printer(console=console).print_exception(exception)
     except click.Abort:
-        Printer(console=console).print_exception(
+        if config.developer_mode:
+            traceback.print_exc()
+        else:
+            Printer(console=console).print_exception(
             StoppedMutableSecurityException()
         )
     except click.BadParameter:
-        Printer(console=console).print_exception(BadArgumentException())
+        if config.developer_mode:
+            traceback.print_exc()
+        else:
+            Printer(console=console).print_exception(BadArgumentException())
     else:
         return
 

--- a/mutablesecurity/cli/cli.py
+++ b/mutablesecurity/cli/cli.py
@@ -279,8 +279,7 @@ def main() -> None:
             traceback.print_exc()
         else:
             Printer(console=console).print_exception(
-            StoppedMutableSecurityException()
-        )
+            StoppedMutableSecurityException())
     except click.BadParameter:
         if config.developer_mode:
             traceback.print_exc()

--- a/mutablesecurity/cli/cli.py
+++ b/mutablesecurity/cli/cli.py
@@ -278,7 +278,8 @@ def main() -> None:
         if config.developer_mode:
             traceback.print_exc()
         else:
-            Printer(console=console).print_exception(StoppedMutableSecurityException())
+            ex = StoppedMutableSecurityException()
+            Printer(console=console).print_exception(ex)
     except click.BadParameter:
         if config.developer_mode:
             traceback.print_exc()


### PR DESCRIPTION
# Metadata

- **Fixed Issue**: #97 

# Improvements

Stack traces will now print when exceptions are thrown in the cli module in a dev environment (when config.developer_mode is true). Pretty print of just the error for non-devs will remain.

# Other Comments
- I didn't use the console.print() used elsewhere in the code to print the stack trace to the console... let me know if traceback.print_exc() doesn't print as you'd like 
- I only added dev environment checking and stack trace to the three places in main where Printer was used to print nice error messages to the user. Let me know if there are other exceptions you'd like a stack trace for.
